### PR TITLE
Added support for arrays of validators and arrays of returned errors

### DIFF
--- a/backbone.validation.js
+++ b/backbone.validation.js
@@ -20,16 +20,14 @@ Backbone.Validation = (function(Backbone, _, undefined) {
 
     var getValidators = function(model, attr) {
 
-        var validationElements = model.validation, validators = [], validationElement, validation;
+        var validationElements = model.validation[attr], validators = [], validationElement, validation;
 
         if( ! _.isArray(validationElements)) {
             validationElements = [validationElements];
         }
 
         for (var i = 0, l = validationElements.length; i < l; i++) {
-            validationElement = validationElements[i];
-
-            validation = validationElement[attr];
+            validation = validationElements[i];
 
             if (_.isFunction(validation)) {
                 validators.push( validation);


### PR DESCRIPTION
Hi I've added support for arrays of validators so that I can have different error messages for different types of error. For example if an email address in missing I see "Please enter an email address". If the email address is present but invalid I see "Please enter a valid email address".

If there is a single error then only that string is returned. If there are multiple errors then the array of errors is returned. I haven't thoroughly tested this I have to admit. Is it reasonably easy for you to push through your test suite? I'll do whatever you require of me I don't want to burden you with untested code, but it works for me

``` javascript
MyModel = Backbone.Model.extend(
{

        validation:
        [{
            name:
            {
                required: true,
                msg: "Please enter a player name"
            },
            email:
            {
                required: true,
                msg: "Please enter an email address"
            }
        },
        {
            email:
            {
                pattern: "email",
                msg: "Please enter a valid email"
            }
        }]
    });
```

It is still possible to pass in a single object for model.validation so it isn't a breaking change
