### PR TITLE
User friendly names for attributes in validation messages

### DIFF
--- a/backbone.validation.js
+++ b/backbone.validation.js
@@ -48,13 +48,14 @@ Backbone.Validation = (function(Backbone, _, undefined) {
 
     var validateAttr = function(model, validation, attr, value, computed) {
         var validators = getValidators(model, validation, attr);
+        var label = model.labels ? model.labels[attr] : undefined;
 
         if (_.isFunction(validators)) {
-            return validators.call(model, value, attr, computed);
+            return validators.call(model, value, label || attr, computed);
         }
 
         return _.reduce(validators, function(memo, validator){
-            var result = validator.fn.call(Backbone.Validation.validators, value, attr, validator.val, model, computed);
+            var result = validator.fn.call(Backbone.Validation.validators, value, label || attr, validator.val, model, computed);
             if(result === false || memo === false) {
                 return false;
             }


### PR DESCRIPTION
this is my first github contribution, so excuse me if I am doing something wrong.

instead of e.g. 'postalCode is required', 'Postal code is required' will be displayed. This saved me from creating a lot of custom validation messages. Please verify if this is acceptable or that it may be better to provide an extra argument to the validator functions, so custom validators which are dependent on the real attr will continue to work.

Example in model:

Backbone.Model.extend({
        validation: {
            postalCode: {
                required: true,
                pattern: 'postalCode'
            },
            houseNumber: {
                required: true
            }
        },

```
    labels: {
        postalCode: 'postal code',
        houseNumber: 'House number'
    }
});
```
