### PR TITLE
Ensure model with custom toJSON() validates correctly

### DIFF
--- a/backbone.validation.js
+++ b/backbone.validation.js
@@ -91,7 +91,7 @@ Backbone.Validation = (function(Backbone, _, undefined) {
             errorMessages = [],
             invalidAttrs = [],
             isValid = true,
-            computed = _.extend(model.toJSON(), attrs);
+            computed = _.extend({}, model.attributes, attrs);
 
         for (changedAttr in attrs) {
             error = validateAttr(model, validation, changedAttr, attrs[changedAttr], computed);
@@ -129,11 +129,11 @@ Backbone.Validation = (function(Backbone, _, undefined) {
         return {
             isValid: function(option) {
                 if(_.isString(option)){
-                    return !validateAttr(this, this.validation, option, this.get(option), this.toJSON());
+                    return !validateAttr(this, this.validation, option, this.get(option), _.extend({}, this.attributes));
                 }
                 if(_.isArray(option)){
                     for (var i = 0; i < option.length; i++) {
-                        if(validateAttr(this, this.validation, option[i], this.get(option[i]), this.toJSON())){
+                        if(validateAttr(this, this.validation, option[i], this.get(option[i]), _.extend({}, this.attributes))){
                             return false;
                         }
                     }
@@ -148,7 +148,7 @@ Backbone.Validation = (function(Backbone, _, undefined) {
                 var model = this,
                     opt = _.extend({}, options, setOptions);
                 if(!attrs){
-                    return model.validate.call(model, _.extend(getValidatedAttrs(model), model.toJSON()));
+                    return model.validate.call(model, _.extend(getValidatedAttrs(model), _.extend({}, model.attributes)));
                 }
 
                 var result = validateObject(view, model, model.validation, attrs, opt);

--- a/tests/general.js
+++ b/tests/general.js
@@ -344,6 +344,29 @@ buster.testCase("Backbone.Validation", {
         }
     },
 
+    "when bound to model with custom toJSON": {
+        setUp: function() {
+            this.model.toJSON = function() {
+                return {
+                    'person': {
+                        'age': this.attributes.age,
+                        'name': this.attributes.name
+                    }
+                }
+            }
+
+            Backbone.Validation.bind(this.view);
+        },
+
+        "and conforming to all validators the model is valid": function (){
+            this.model.set({age: 12});
+            this.model.set({name: 'Jack'});
+
+            this.model.validate()
+            assert(this.model.isValid())
+        }
+    },
+
     "when bound to model with three validators on one attribute": {
         setUp: function() {
             this.Model = Backbone.Model.extend({


### PR DESCRIPTION
We ran into a situation where one of our models with a custom toJSON method was not validating because the validation routines call toJSON on the model to copy a "frozen" state of the object's attributes. We changed the validations to use _.extend to make a copy instead.
