### PR TITLE
Added an isolatedValidation option to the validateObject method

### DIFF
--- a/backbone.validation.js
+++ b/backbone.validation.js
@@ -114,7 +114,7 @@ Backbone.Validation = (function(Backbone, _, undefined) {
             }
         }
 
-        if (isValid) {
+        if (isValid && !options.isolatedValidation) {
             isValid = validateAll(model, validation, attrs, computed, view, options);
         }
 


### PR DESCRIPTION
This isolatedValidation option ensures that only validations for the changed attrs will fire, and not the entire model (or the previously set attrs). This is a solution to the [Issue #54](https://github.com/thedersen/backbone.validation/issues/54) ticket I opened earlier this week. I'll associate the pull request with the issue tonight when I get to a machine where I can install the hub command line tools.

Essentially this prevents the valid and invalid callbacks from being fired for attributes that the user hasn't set, preventing a field populated by an invalid value from firing. See the issue for more details.
