### PR TITLE
equalTo comparison is not working due to comparison against incorrect value

### DIFF
--- a/backbone.validation.js
+++ b/backbone.validation.js
@@ -507,7 +507,7 @@
 
       // Equal to validator
       equalTo: function(value, attr, equalTo, model, computed) {
-        if(value !== computed[equalTo]) {
+        if(value !== equalTo) {
           return format(defaultMessages.equalTo, formatLabel(attr, model), formatLabel(equalTo, model));
         }
       },


### PR DESCRIPTION
We found that the `equalTo` comparison was comparing against an undefined value, which came from `computed[equalTo]`. The `equalTo` argument already contains the value you want to compare against, for example "100", whereas `computed` is a hash of attributes such as `{foo: 1, bar: 2}`. So it makes no sense to use equalTo as the key to pull something out of that hash. 

`equalTo` is already the thing you should use to compare against. Not sure about the purpose of the `computed` argument, but this fix appears to fix the problem. Please let me know if something seems off about this.
