### PR TITLE
Update validate method so that valid callbacks are executed before invalid callbacks.

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -149,15 +149,21 @@ Backbone.Validation = (function(_){
           model._isValid = result.isValid;
 
           // After validation is performed, loop through all changed attributes
-          // and call either the valid or invalid callback so the view is updated.
+          // and call the valid callbacks so the view is updated.
+          for(var attr in allAttrs) {
+            var invalid = result.invalidAttrs.hasOwnProperty(attr);
+            if(!invalid){
+              opt.valid(view, attr, opt.selector);
+            }
+          }
+
+          // After validation is performed, loop through all changed attributes
+          // and call the invalid callback so the view is updated.
           for(var attr in allAttrs) {
             var invalid = result.invalidAttrs.hasOwnProperty(attr),
                 changed = changedAttrs.hasOwnProperty(attr);
             if(invalid && (changed || validateAll)){
               opt.invalid(view, attr, result.invalidAttrs[attr], opt.selector);
-            }
-            if(!invalid){
-              opt.valid(view, attr, opt.selector);
             }
           }
 


### PR DESCRIPTION
I was working with Backbone.Validation and Twitter Bootstrap. I had a group of controls under a single "control-group" container and when one field is invalid the container was marked as such, but then other fields that were valid would then remove the "error" class.

I was looking at the code, and it seems to me that the validations could be run with the valid fields first, then the invalid ones. In the cases where order doesn't matter, this shouldn't affect anything. In cases where order does matter, this change keeps the valid fields from potentially removing error classes.

Sorry for the unrequested pull, but I thought it was a pretty simple change.
