### PR TITLE
Update src/backbone-validation.js

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -8,6 +8,7 @@ Backbone.Validation = (function(_){
       forceUpdate: false,
       selector: 'name',
       labelFormatter: 'sentenceCase',
+      ignoredChangeSources: [],
       valid: Function.prototype,
       invalid: Function.prototype
   };
@@ -145,7 +146,9 @@ Backbone.Validation = (function(_){
               allAttrs = _.extend(getValidatedAttrs(model), model.attributes, attrs),
               changedAttrs = attrs || allAttrs,
               result = validateModel(model, allAttrs);
-
+          
+          if(_.contains(opt.ignoredChangeSources, setOptions.changeSource)) return;
+          
           model._isValid = result.isValid;
 
           // After validation is performed, loop through all changed attributes


### PR DESCRIPTION
When using a model/view binder in a form, the validator is called after
a form field is edited because the binder sets the new value to the model.
This could be annoying if you just want to fill out the form out and 
then only validate on save. There could be an option to only validate
on save, or there could be an option to ignore change sources. The
changeSource variable is given to us from the setOptions argument in
the validate function. We could use this to determine whether or not
to validate. In my case - Backbone.Validation.configure ignoredChangeSources: ['ModelBinder']
