### PR TITLE
Require a changed value or the validateAll flag, in addition to a valid value, before calling the valid() callback on an attribute

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -213,8 +213,9 @@ Backbone.Validation = (function(_){
           // After validation is performed, loop through all changed attributes
           // and call the valid callbacks so the view is updated.
           _.each(validatedAttrs, function(val, attr){
-            var invalid = result.invalidAttrs.hasOwnProperty(attr);
-            if(!invalid){
+            var invalid = result.invalidAttrs.hasOwnProperty(attr),
+                changed = changedAttrs.hasOwnProperty(attr);
+            if(!invalid && (changed || validateAll)){
               opt.valid(view, attr, opt.selector);
             }
           });


### PR DESCRIPTION
Hi,

I'm scratching my head wondering why the lines in this commit, which simply make the conditions for calling the `valid()` callback on attributes symmetrical to the those for the `invalid()` callback, aren't there.

Somehow I'm worried that it was an intentional omission, yet without these lines, if a single field on a form that contains multiple fields more than one of which have been marked invalid, turns from invalid to valid, the `valid()` callback will end up being called on all valid model attributes, even if they are in an unsaved, invalid state in the view.

But maybe it just got overlooked... If so, I'm glad to be able to contribute it, and hope you'll consider adding it to `master`.

Thanks a lot for the awesome work!
Sean
