### PR TITLE
Replace all the underscores in sentenceCase formatter

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -418,7 +418,7 @@ Backbone.Validation = (function(_){
     sentenceCase: function(attrName) {
       return attrName.replace(/(?:^\w|[A-Z]|\b\w)/g, function(match, index) {
         return index === 0 ? match.toUpperCase() : ' ' + match.toLowerCase();
-      }).replace('_', ' ');
+      }).replace(/_/g, ' ');
     },
 
     // Looks for a label configured on the model and returns it


### PR DESCRIPTION
The sentence case formatter replaced only the first underscore.
