### PR TITLE
Play nice with associations

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -57,6 +57,12 @@ Backbone.Validation = (function(_){
 
     _.each(obj, function(val, key) {
       if(obj.hasOwnProperty(key)) {
+        // play nice with associations -- don't flatten an entire Backbone.Model,
+        // including event bindings etc. that would lead to a call stack overflow
+        if (val && (val instanceof Backbone.Model)) {
+          val = val.attributes
+        }
+
         if (val && typeof val === 'object' && !(val instanceof Date || val instanceof RegExp)) {
           flatten(val, into, prefix + key + '.');
         }


### PR DESCRIPTION
When my models have associations, backbone.validation's flatten method leads to call stack overflows. What happens is that it flattens the entire Backbone model, event bindings and all. And in the cause of that it just descends and descends and descends the hierarchy ad infinitum.

Simple solution: when a value we encounter is a Backbone.Model, we unwrap it and look only at the attributes. This seems to work fine.

The associations library I use that causes this is here:
https://github.com/rjz/backbone.associate
