### PR TITLE
handling id selectors better

### DIFF
--- a/examples/js/backbone.validation.bootstrap.js
+++ b/examples/js/backbone.validation.bootstrap.js
@@ -1,5 +1,8 @@
 _.extend(Backbone.Validation.callbacks, {
   valid: function(view, attr, selector){
+    selector = (selector == 'id'
+                ? '#' + attr
+                : '[' + selector + '=' + attr + ']');
     var control = view.$('[' + selector + '=' + attr + ']');
     var group = control.parents(".control-group");
     group.removeClass("error");
@@ -18,6 +21,9 @@ _.extend(Backbone.Validation.callbacks, {
     }
   },
   invalid: function(view, attr, error, selector) {
+    selector = (selector == 'id'
+                ? '#' + attr
+                : '[' + selector + '=' + attr + ']');
     var control = view.$('[' + selector + '=' + attr + ']');
     var group = control.parents(".control-group");
     group.addClass("error");


### PR DESCRIPTION
If `selector` is set to `id` in the configuration, it will now use `#id` (rather than the much slower `[id=attr]`) to look up the element.
