### PR TITLE
Fixes infinite loop issues when recursing into Backbone objects with event bindings

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -57,7 +57,7 @@ Backbone.Validation = (function(_){
 
     _.each(obj, function(val, key) {
       if(obj.hasOwnProperty(key)) {
-        if (val && typeof val === 'object' && !(val instanceof Date || val instanceof RegExp)) {
+        if (val && typeof val === 'object' && !(val instanceof Date || val instanceof RegExp) && !(val instanceof Backbone.Model) && !(val instanceof Backbone.Collection)) {
           flatten(val, into, prefix + key + '.');
         }
         else {

--- a/tests/isValid.js
+++ b/tests/isValid.js
@@ -45,6 +45,20 @@ buster.testCase("isValid", {
 			assert(this.model.isValid(true) === false);
 		},
 
+		"avoids infinite loop and returns true when backbone model is present with attached event bindings": function () {
+			var instance = new Backbone.Model();
+			instance.on('event', function () {});
+			this.model.set('name', instance);
+			assert(this.model.isValid());
+		},
+
+		"avoids infinite loop and returns true when backbone collection is present with attached event bindings": function () {
+			var instance = new Backbone.Collection();
+			instance.on('event', function () {});
+			this.model.set('name', instance);
+			assert(this.model.isValid());
+		},
+
 		"and passing name of attribute": {
 			setUp: function() {
 				this.model.validation = {


### PR DESCRIPTION
This is a pretty simple pull request that solves the issue of an infinite loop occurring with nested backbone objects with event bindings.

The solution is quite simple: check if the property is a backbone object when flattening and if it is, just take the object rather than looping through its attributes.
