### PR TITLE
Fix error in selector in inValid() method

### DIFF
--- a/examples/js/backbone.validation.bootstrap.js
+++ b/examples/js/backbone.validation.bootstrap.js
@@ -24,7 +24,7 @@ _.extend(Backbone.Validation.callbacks, {
     selector = (selector == 'id'
                 ? '#' + attr
                 : '[' + selector + '=' + attr + ']');
-    var control = view.$('[' + selector + '=' + attr + ']');
+    var control = view.$(selector);
     var group = control.parents(".control-group");
     group.addClass("error");
 


### PR DESCRIPTION
Was getting error in example included in the plugin. During debugging found problem with below code in invalid() method:

```
selector = (selector == 'id'
            ? '#' + attr
            : '[' + selector + '=' + attr + ']');
var control = view.$('[' + selector + '=' + attr + ']');
```

Made the necessary changes with selector now so please review and do the needful accordingly.

```
selector = (selector == 'id'
            ? '#' + attr
            : '[' + selector + '=' + attr + ']');
var control = view.$(selector);
```
