### PR TITLE
Added a validation to check if object is array in flatten.

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -57,7 +57,8 @@ Backbone.Validation = (function(_){
 
     _.each(obj, function(val, key) {
       if(obj.hasOwnProperty(key)) {
-        if (val && typeof val === 'object' && !(
+        if (val && typeof val === 'object' &&
+          Object.prototype.toString.call(val) !== '[object Array]' && !( //Check if object is an array
           val instanceof Date ||
           val instanceof RegExp ||
           val instanceof Backbone.Model ||


### PR DESCRIPTION
Recently I faced the need to validate an array attribute of a model. I wrote my custom validation function and I was surprised to see that the validation was never executed. I traced the issue to the "flatten" function which checked for objects and called the "flatten" function recursively. At that point the attribute was not returned as it didn't meet the criteria for object.

Anyway, I thought it would be worth it to post this, so I added a little validation to the "flatten" function to make sure arrays are not treated as objects.

Please let me know what you think of this. I am opened to comments.

Thanks :)
