### PR TITLE
fixed model unbind when model is also part of a collection

### DIFF
--- a/dist/backbone-validation-amd.js
+++ b/dist/backbone-validation-amd.js
@@ -354,7 +354,7 @@
           if(model) {
             unbindModel(model);
           }
-          if(collection) {
+          else if(collection) {
             collection.each(function(model){
               unbindModel(model);
             });

--- a/dist/backbone-validation.js
+++ b/dist/backbone-validation.js
@@ -347,7 +347,7 @@ Backbone.Validation = (function(_){
         if(model) {
           unbindModel(model);
         }
-        if(collection) {
+        else if(collection) {
           collection.each(function(model){
             unbindModel(model);
           });

--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -340,7 +340,7 @@ Backbone.Validation = (function(_){
         if(model) {
           unbindModel(model);
         }
-        if(collection) {
+        else if(collection) {
           collection.each(function(model){
             unbindModel(model);
           });


### PR DESCRIPTION
When calling unbind(this), I fixed a bug due to a missing 'else' where even if the view had a model, if the model was also part of a collection, all other collection models would be unbound. I don't think this is the correct behavior since different views that are concurrently showing may decide to change which model they are displaying. Without this fix, if one view did an unbind(), retrieved a new model, and then called bind(), then any other views would be unbound as well!

Please review,
Kimon
