### PR TITLE
Bugfix for Collection binding

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -321,8 +321,8 @@ Backbone.Validation = (function(_){
         if(model) {
           bindModel(view, model, options);
         }
-        else if(collection) {
-          collection.each(function(model){
+        if(collection) {
+          collection.models.each(function(model){
             bindModel(view, model, options);
           });
           collection.bind('add', collectionAdd, {view: view, options: options});


### PR DESCRIPTION
1) If model is "true" we did not bind collection, so need to use "if" instead of "else if".
2) collection is object and we can't use ".each" on it. So need to use "collection.models" instead of "collection".
