### PR TITLE
Removed redundant semicolon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ var SomeModel = Backbone.Model.extend({
     return {
       name: {
         required: true
-      };
+      }
     }
   }
 });


### PR DESCRIPTION
I fixed a small mistake in the example.