### PR TITLE
#245 fix : Only validate properties on the model that exist in the form

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -228,7 +228,9 @@ Backbone.Validation = (function(_){
               allAttrs = _.extend({}, validatedAttrs, model.attributes, attrs),
               changedAttrs = flatten(attrs || allAttrs),
 
-              result = validateModel(model, allAttrs);
+              // If the option changedAttrs is passed and is true, then only validate against the changed attributes
+              // as opposed to the entire mode.
+              result = validateModel(model, opt.changedAttrs ? changedAttrs : allAttrs);
 
           model._isValid = result.isValid;
 


### PR DESCRIPTION
I have a solution that works pretty well and only modifies the existing code a small amount.
The user can call the validate method on the model and pass an option changedAttrs : true.

For example : this.set(user, {validate : true, changedAttrs : true});

Then in the backbone-validation.js file in the validate mixin on line 223, the result variable (line 233) can be set by checking for the changedAttrs option, if it exists, then it only validates the changed attributes or the ones sent in the form.

For example : result = validateModel(model, opt.changedAttrs ? changedAttrs : allAttrs);

That way I can choose to validate just the form components without having to make a model for each form and also if I want, I can validate the entire model if I ever need to.
