### PR TITLE
Support intermediate nested levels

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -74,13 +74,11 @@ Backbone.Validation = (function(_){
 
     _.each(obj, function(val, key) {
       if(obj.hasOwnProperty(key)) {
-        var shouldFlatten = !!val && typeof val === 'object' && val.constructor === Object;
-
-        if (shouldFlatten) {
+        if (!!val && typeof val === 'object' && val.constructor === Object) {
           flatten(val, into, prefix + key + '.');
         }
 
-        // Register the intermediate object
+        // Register the current level object as well
         into[prefix + key] = val;
       }
     });

--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -39,43 +39,35 @@ Backbone.Validation = (function(_){
   // eg:
   //
   //     var o = {
-  //       address: {
+  //       owner: {
+  //         name: 'Backbone',
+  //         address: {
+  //           street: 'Street',
+  //           zip: 1234
+  //         }
+  //       }
+  //     };
+  //
+  // becomes:
+  //
+  //     var o = {
+  //       'owner': {
+  //         name: 'Backbone',
+  //         address: {
+  //           street: 'Street',
+  //           zip: 1234
+  //         }
+  //       },
+  //       'owner.name': 'Backbone',
+  //       'owner.address': {
   //         street: 'Street',
   //         zip: 1234
-  //       }
-  //     };
-  //
-  // becomes:
-  //
-  //     var o = {
-  //       'address.street': 'Street',
-  //       'address.zip': 1234
-  //     };
-  // If preserveLevels is true, will also preserve intermediate levels of
-  // objects to allow for partial nesting of validators.
-  // eg:
-  //
-  //     var o = {
-  //       multiLevelObject: {
-  //         firstLevel: {
-  //           key: 'value'
-  //         }
-  //       }
-  //     };
-  //
-  // becomes:
-  //
-  //     var o = {
-  //       'multiLevelObject': {
-  //         firstLevel: {
-  //           key: 'value'
-  //         }
   //       },
-  //       'multiLevelObject.firstLevel': {
-  //         key: 'value'
-  //       },
-  //       'multiLevelObject.firstLevel.key': 'value'
+  //       'owner.address.street': 'Street',
+  //       'owner.address.zip': 1234
   //     };
+  // This may seem redundant, but it allows for maximum flexibility
+  // in validation rules.
   var flatten = function (obj, into, prefix) {
     into = into || {};
     prefix = prefix || '';

--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -76,7 +76,7 @@ Backbone.Validation = (function(_){
   //       },
   //       'multiLevelObject.firstLevel.key': 'value'
   //     };
-  var flatten = function (obj, preserveLevels, into, prefix) {
+  var flatten = function (obj, into, prefix) {
     into = into || {};
     prefix = prefix || '';
 
@@ -85,13 +85,11 @@ Backbone.Validation = (function(_){
         var shouldFlatten = !!val && typeof val === 'object' && val.constructor === Object;
 
         if (shouldFlatten) {
-          flatten(val, preserveLevels, into, prefix + key + '.');
+          flatten(val, into, prefix + key + '.');
         }
 
-        if (!shouldFlatten || preserveLevels) {
-          // Register the intermediate object
-          into[prefix + key] = val;
-        }
+        // Register the intermediate object
+        into[prefix + key] = val;
       }
     });
 
@@ -193,7 +191,7 @@ Backbone.Validation = (function(_){
           invalidAttrs = {},
           isValid = true,
           computed = _.clone(attrs),
-          flattened = _.pick(flatten(attrs, true), validatedKeys);
+          flattened = _.pick(flatten(attrs), validatedKeys);
 
       _.each(flattened, function(val, attr) {
         error = validateAttr(model, attr, val, computed);
@@ -239,7 +237,7 @@ Backbone.Validation = (function(_){
         // entire model is valid. Passing true will force a validation
         // of the model.
         isValid: function(option) {
-          var flattened = flatten(this.attributes, true);
+          var flattened = flatten(this.attributes);
 
          option = option || getOptionsAttrs(options, view);
 
@@ -266,7 +264,7 @@ Backbone.Validation = (function(_){
               opt = _.extend({}, options, setOptions),
               validatedAttrs = getValidatedAttrs(model, getOptionsAttrs(options, view)),
               allAttrs = _.extend({}, validatedAttrs, model.attributes, attrs),
-              changedAttrs = flatten(attrs || allAttrs, true),
+              changedAttrs = flatten(attrs || allAttrs),
 
               result = validateModel(model, allAttrs, _.keys(validatedAttrs));
 

--- a/tests/nestedValidation.js
+++ b/tests/nestedValidation.js
@@ -271,6 +271,129 @@ buster.testCase('Nested validation', {
     }
   },
 
+  "complex nesting with intermediate-level validators": {
+    setUp: function() {
+      this.valid = this.spy();
+      this.invalid = this.spy();
+  
+      var Model = Backbone.Model.extend({
+        validation: {
+          'foo.bar': {
+            fn: 'validateBazAndQux',
+            msg: 'bazQuxError1'
+          },
+          'foo.foo': {
+            fn: 'validateBazAndQux',
+            msg: 'bazQuxError2'
+          }
+        },
+        validateBazAndQux: function (value, attr, computedState) {
+          if (!value || !value.baz || !value.qux) {
+            return "error";
+          }
+        }
+      });
+  
+      this.model = new Model();
+      this.view = new Backbone.View({model: this.model});
+      
+      Backbone.Validation.bind(this.view, {
+        invalid: this.invalid,
+        valid: this.valid
+      });
+    },
+
+    "invalid": {
+      setUp: function () {
+        this.result = this.model.set({
+          foo: {
+            bar: {
+              baz: '',
+              qux: 'qux'
+            },
+            foo: {
+              baz: 'baz',
+              qux: ''
+            }
+          }
+        }, {validate: true});
+      },
+  
+      "refutes setting invalid values": function() {
+        refute(this.result);
+      },
+  
+      "calls the invalid callback": function() {
+        assert.calledWith(this.invalid, this.view, 'foo.bar', 'bazQuxError1');
+        assert.calledWith(this.invalid, this.view, 'foo.foo', 'bazQuxError2');
+      },
+  
+      "isValid returns false for the specified attribute name": function () {
+        refute(this.model.isValid('foo.bar'));
+        refute(this.model.isValid('foo.foo'));
+      },
+  
+      "isValid returns false for the specified attribute names": function () {
+        refute(this.model.isValid(['foo.foo', 'foo.bar']));
+      },
+  
+      "preValidate returns error message for the specified attribute name": function () {
+        assert(this.model.preValidate('foo.bar', ''));
+        assert(this.model.preValidate('foo.foo', ''));
+      },
+
+      "preValidate does not return error message if new nested values validate": function () {
+        refute(this.model.preValidate('foo.bar', { baz: 1, qux: 1 }));
+        refute(this.model.preValidate('foo.foo', { baz: 1, qux: 1 }));
+      }
+    },
+
+    "valid": {
+      setUp: function () {
+        this.result = this.model.set({
+          foo: {
+            bar: {
+              baz: 'val',
+              qux: 'val'
+            },
+            foo: {
+              baz: 'val',
+              qux: 'val'
+            }
+          }
+        }, {validate: true});
+      },
+  
+      "sets the value": function() {
+        assert(this.result);
+      },
+  
+      "calls the valid callback": function() {
+        assert.calledWith(this.valid, this.view, 'foo.bar');
+        assert.calledWith(this.valid, this.view, 'foo.foo');
+      },
+  
+      "isValid returns true for the specified attribute name": function () {
+        assert(this.model.isValid('foo.bar'));
+        assert(this.model.isValid('foo.foo'));
+      },
+  
+      "isValid returns true for the specified attribute names": function () {
+        assert(this.model.isValid(['foo.bar', 'foo.foo']));
+      },
+  
+      "preValidate returns no error message for the specified attribute name": function () {
+        refute(this.model.preValidate('foo.bar', { baz: 1, qux: 1 }));
+        refute(this.model.preValidate('foo.foo', { baz: 1, qux: 1 }));
+      },
+
+      "preValidate returns error message if new nested values do not validate": function () {
+        assert.equals(this.model.preValidate('foo.bar', { baz: '', qux: '' }), 'bazQuxError1');
+        assert.equals(this.model.preValidate('foo.foo', { baz: '', qux: '' }), 'bazQuxError2');
+      }
+    }
+  },
+
   "nested models and collections": {
     setUp: function () {
       this.valid = this.spy();


### PR DESCRIPTION
This should fix #261. As noted in the commit comments, there may be room for improvement. **I don't think this should be merged just yet**, personally, and I would appreciate a review from anyone else who might have some insights.

I implemented for flexibility between flatten-with-intermediate-levels-preserved and flatten-without-intermediate-levels-preserved, but I'm not 100% sure if that's necessary. I'm not happy that the validate --> validateModel path flattens twice, but I was unable to get the tests to pass without that. If anyone has any suggestions for improving the flow, please leave a comment.

Please also let me know if the unit tests need improvement.