### PR TITLE
Reorganizing required validator tests

### DIFF
--- a/tests/validators/required.js
+++ b/tests/validators/required.js
@@ -1,140 +1,191 @@
 buster.testCase("required validator", {
-    setUp: function() {
-        var that = this;
-        var Model = Backbone.Model.extend({
-            validation: {
-                name: {
-                    required: true
-                },
-                agree: {
-                    required: true
-                },
-                posts: {
-                    required: true
-                },
-                dependsOnName: {
-                    required: function(val, attr, computed) {
-                        that.ctx = this;
-                        that.attr = attr;
-                        that.computed = computed;
-                        return this.get('name') === 'name';
+    "valid and invalid values": {
+        setUp: function() {
+            var Model = Backbone.Model.extend({
+                validation: {
+                    name: {
+                        required: true
+                    },
+                    agree: {
+                        required: true
+                    },
+                    posts: {
+                        required: true
                     }
                 }
+            });
+
+            _.extend(Model.prototype, Backbone.Validation.mixin);
+
+            this.model = new Model({
+                name: 'name',
+                agree: true,
+                posts: ['post'],
+            });
+        },
+
+        "empty string is invalid": function() {
+            refute(this.model.set({
+                name: ''
+            }, {validate: true}));
+        },
+
+        "non-empty string is valid": function() {
+            assert(this.model.set({
+                name: 'a'
+            }, {validate: true}));
+        },
+
+        "string with just spaces is invalid": function() {
+            refute(this.model.set({
+                name: '  '
+            }, {validate: true}));
+        },
+
+        "null is invalid": function() {
+            refute(this.model.set({
+                name: null
+            }, {validate: true}));
+        },
+
+        "undefined is invalid": function() {
+            refute(this.model.set({
+                name: void 0
+            }, {validate: true}));
+        },
+
+        "false boolean is valid": function() {
+            assert(this.model.set({
+                agree: false
+            }, {validate: true}));
+        },
+
+        "true boolean is valid": function() {
+            assert(this.model.set({
+                agree: true
+            }, {validate: true}));
+        },
+
+        "empty array is invalid": function() {
+            refute(this.model.set({
+                posts: []
+            }, {validate: true}));
+        },
+
+        "non-empty array is valid": function() {
+            assert(this.model.set({
+                posts: ['post']
+            }, {validate: true}));
+        }
+    },
+
+    "default error message": {
+        setUp: function () {
+            var Model = Backbone.Model.extend({
+                validation: {
+                    name: {
+                        required: true
+                    }
+                }
+            });
+
+            _.extend(Model.prototype, Backbone.Validation.mixin);
+
+            this.model = new Model({ name: "name" });
+        },
+
+        "message is sent to validated:invalid event": function (done) {
+            this.model.bind('validated:invalid', function(model, error){
+                assert.equals({ name: 'Name is required' }, error);
+                done();
+            });
+
+            this.model.set({ name: '' }, { validate: true });
+        },
+
+        "message is sent to invalid function": function () {
+            var invalid = this.spy();
+
+            var view = new Backbone.View({ model: this.model });
+
+            Backbone.Validation.bind(view, {
+                invalid: invalid
+            });
+
+            this.model.set({ name: '' }, { validate: true });
+
+            assert.calledWith(invalid, view, "name", "Name is required");
+        }
+    },
+
+    "required as a function": {
+        setUp: function () {
+            this.requiredSpy = this.spy(function (value, attr, computed) {
+                return this.get("shouldRequireName");
+            });
+
+            var Model = Backbone.Model.extend({
+                validation: {
+                    shouldRequireName: {
+                        required: true,
+                    },
+                    name: {
+                        required: this.requiredSpy
+                    }
+                }
+            });
+
+            _.extend(Model.prototype, Backbone.Validation.mixin);
+
+            this.model = new Model();
+        },
+
+        "required function call": {
+            setUp: function () {
+                this.model.set({
+                    name: "name value",
+                    shouldRequireName: true
+                }, { validate: true });
+            },
+
+            "function is called on model": function () {
+                assert.calledOn(this.requiredSpy, this.model);
+            },
+
+            "function is called with value, attribute name, and computed": function () {
+                assert.calledWith(this.requiredSpy, "name value", "name", {
+                    name: "name value",
+                    shouldRequireName: true
+                });
             }
-        });
+        },
 
-        this.model = new Model({
-            name: 'name',
-            agree: true,
-            posts: ['post'],
-            dependsOnName: 'depends'
-        });
-        this.view = new Backbone.View({
-            model: this.model
-        });
+        "value not required": {
+            setUp: function () {
+                this.model.set("shouldRequireName", false);
+            },
 
-        Backbone.Validation.bind(this.view, {
-            valid: this.spy(),
-            invalid: this.spy()
-        });
-    },
+            "setting invalid value is allowed": function () {
+                assert(this.model.set("name", void 0, { validate: true }));
+            },
 
-    "has default error message": function(done) {
-        this.model.bind('validated:invalid', function(model, error){
-            assert.equals({name: 'Name is required'}, error);
-            done();
-        });
-        this.model.set({name:''}, {validate: true});
-    },
+            "setting valid value is allowed": function () {
+                assert(this.model.set("name", "valid", { validate: true }));
+            }
+        },
 
-    "empty string is invalid": function() {
-        refute(this.model.set({
-            name: ''
-        }, {validate: true}));
-    },
+        "value required": {
+            setUp: function () {
+                this.model.set("shouldRequireName", true);
+            },
 
-    "non-empty string is valid": function() {
-        assert(this.model.set({
-            name: 'a'
-        }, {validate: true}));
-    },
+            "setting invalid value is not allowed": function () {
+                refute(this.model.set("name", void 0, { validate: true }));
+            },
 
-    "string with just spaces is invalid": function() {
-        refute(this.model.set({
-            name: '  '
-        }, {validate: true}));
-    },
-
-    "null is invalid": function() {
-        refute(this.model.set({
-            name: null
-        }, {validate: true}));
-    },
-
-    "undefined is invalid": function() {
-        refute(this.model.set({
-            name: undefined
-        }, {validate: true}));
-    },
-
-    "false boolean is valid": function() {
-        assert(this.model.set({
-            agree: false
-        }, {validate: true}));
-    },
-
-    "true boolean is valid": function() {
-        assert(this.model.set({
-            agree: true
-        }, {validate: true}));
-    },
-
-    "empty array is invalid": function() {
-        refute(this.model.set({
-            posts: []
-        }, {validate: true}));
-    },
-
-    "non-empty array is valid": function() {
-        assert(this.model.set({
-            posts: ['post']
-        }, {validate: true}));
-    },
-
-    "required can be specified as a method returning true or false": function() {
-        this.model.set({name:'aaa'}, {validate: true});
-
-        assert(this.model.set({
-            dependsOnName: undefined
-        }, {validate: true}));
-
-        this.model.set({name:'name'}, {validate: true});
-
-        refute(this.model.set({
-            dependsOnName: undefined
-        }, {validate: true}));
-    },
-
-    "context is the model": function() {
-        this.model.set({
-            dependsOnName: ''
-        }, {validate: true});
-        assert.same(this.ctx, this.model);
-    },
-
-    "second argument is the name of the attribute being validated": function() {
-        this.model.set({dependsOnName: ''}, {validate: true});
-        assert.equals('dependsOnName', this.attr);
-    },
-
-    "third argument is a computed model state": function() {
-        this.model.set({attr: 'attr'});
-        this.model.set({
-            name: 'name',
-            posts: ['post'],
-            dependsOnName: 'value'
-        }, {validate: true});
-
-        assert.equals({agree:true, attr:'attr', dependsOnName:'value', name:'name', posts: ['post']}, this.computed);
+            "setting valid value is allowed": function () {
+                assert(this.model.set("name", "valid", { validate: true }));
+            }
+        }
     }
 });


### PR DESCRIPTION
I wanted to submit a patch to reorganize the tests around the "required" validator. Some of the tests were hard to follow because the setup was hundreds of lines above the test and there were a lot of references to shared variables as well.

Here's the rough organization I drew up:
- Valid and invalid values
  - Empty string, space-filled string, null, undefined, empty array are invalid
  - Non-empty string, false/true, and non-empty array are valid
- Default error message
  - Message is sent to `validated:invalid` event
  - Message is sent to `invalid` callback
- Required as a function
  - Required function call
    - Function is called on model
    - Function is called with value, attribute name, and computed
  - Value not required
    - Setting invalid value is allowed
    - Setting valid value is allowed
  - Value required
    - Setting invalid value is not allowed
    - Setting valid value is allowed

**Collaborators will want to review this carefully** to make sure I didn't inadvertently reduce coverage. There should be no functionality changes in this pull request.
