### PR TITLE
Check for no associatedViews in unbindModel()

### DIFF
--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -325,7 +325,7 @@ Backbone.Validation = (function(_){
     // Removes view from associated views of the model or the methods
     // added to a model if no view or single view provided
     var unbindModel = function(model, view) {
-      if (view && model.associatedViews.length > 1){
+      if (view && !_.isEmpty(model.associatedViews)){
         model.associatedViews = _.without(model.associatedViews, view);
       } else {
         delete model.validate;

--- a/src/backbone-validation.js
+++ b/src/backbone-validation.js
@@ -325,7 +325,7 @@ Backbone.Validation = (function(_){
     // Removes view from associated views of the model or the methods
     // added to a model if no view or single view provided
     var unbindModel = function(model, view) {
-      if (view && !_.isEmpty(model.associatedViews)){
+      if (view && model.associatedViews && model.associatedViews.length > 1){
         model.associatedViews = _.without(model.associatedViews, view);
       } else {
         delete model.validate;

--- a/tests/general.js
+++ b/tests/general.js
@@ -52,6 +52,13 @@ buster.testCase("Backbone.Validation", {
         }
     },
 
+    "when unbinding view which was not bound": {
+        "nothing happens": function(){
+            Backbone.Validation.unbind(new Backbone.View({model:new Backbone.Model()}));
+            assert(true);
+        }
+    },
+
     "when bound to model with two validated attributes": {
         setUp: function() {
             Backbone.Validation.bind(this.view);


### PR DESCRIPTION
Fix error when unbind gets invoked on a model/ view which has no binded views.
Modified unbindModel() to check for a non empty list of model.associatedViews, before removing the view from associated views