### PR TITLE
Use files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,18 +28,22 @@
     "prepublish": "grunt"
   },
   "main": "./dist/backbone-validation-amd.js",
+  "files": [
+    "dist/backbone-validation-amd.js"
+  ],
   "dependencies": {
     "backbone": ">=1.0.0",
     "underscore": ">=1.4.3"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
     "buster": "~0.7.8",
-    "grunt-docco": ">=0.3.0",
-    "grunt-shell": ">=0.1.3",
-    "grunt-rigger": ">=0.3.0",
+    "grunt": "~0.4.1",
     "grunt-buster": "~0.3.1",
     "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-uglify": "~0.2.2"
+    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-docco": ">=0.3.0",
+    "grunt-rigger": ">=0.3.0",
+    "grunt-shell": ">=0.1.3",
+    "phantomjs": "^1.9.16"
   }
 }


### PR DESCRIPTION
Reduces amount of files consumer gets when `npm install`ing.

Before: http://hastebin.com/wacequlono.sh
After: http://hastebin.com/karavebiko.sh

I also added `phantomjs` to devDeps. I expect `npm install && npm test` to not explode because of missing dependencies :smile: 

`npm install <package>` automatically alphabetizes the list