### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
     "url": "http://thedersen.com/"
   },
   "homepage": "http://thedersen.com/projects/backbone-validation",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://thedersen.mit-license.org/"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "http://github.com/thedersen/backbone.validation/issues"
   },


### PR DESCRIPTION
Array deprecated in npm@2.10.0

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license

Should fix `license` image from shields in the readme as well