### PR TITLE
Fixed small typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Validates that the value has to be equal to one of the elements in the specified
 var SomeModel = Backbone.Model.extend({
   validation: {
     country: {
-      oneOf: ['Norway', 'Sweeden']
+      oneOf: ['Norway', 'Sweden']
     }
   }
 });


### PR DESCRIPTION
Fixed typo in validators' examples:
Sweeden → Sweden
